### PR TITLE
Fix Astro build by adding getStaticPaths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules
 .DS_Store
+dist
+.astro

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -1,6 +1,12 @@
 ---
 import Layout from '../../layouts/Layout.astro';
-import { getEntry } from 'astro:content';
+import { getCollection, getEntry } from 'astro:content';
+
+export async function getStaticPaths() {
+  const posts = await getCollection('blog');
+  return posts.map(post => ({ params: { slug: post.slug } }));
+}
+
 const { slug } = Astro.params;
 const post = await getEntry('blog', slug);
 ---


### PR DESCRIPTION
## Summary
- generate static paths for blog posts
- ignore build output and .astro cache

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68517e6b5e4c8323a46c829f8873aea6