### PR TITLE
Add middleware to set security headers

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,17 @@
+import type { MiddlewareHandler } from 'astro';
+
+export const onRequest: MiddlewareHandler = async ({ request }, next) => {
+  const response = await next();
+
+  response.headers.set('X-Frame-Options', 'DENY');
+  response.headers.set('X-Content-Type-Options', 'nosniff');
+  response.headers.set('X-XSS-Protection', '1; mode=block');
+  response.headers.set('Referrer-Policy', 'no-referrer-when-downgrade');
+  response.headers.set('Strict-Transport-Security', 'max-age=63072000; includeSubDomains; preload');
+  response.headers.set(
+    'Content-Security-Policy',
+    "default-src 'self'; img-src 'self' https:; script-src 'self'; style-src 'self' 'unsafe-inline';"
+  );
+
+  return response;
+};


### PR DESCRIPTION
## Summary
- add `src/middleware.ts` with security headers for Astro

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685c58976f30832388c6c70d74dafb11