### PR TITLE
Improve security headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ To build for production:
 npm run build
 ```
 
+## Security Headers
+
+This site includes middleware and static header configuration to set recommended
+security headers. These headers help the site achieve a passing score on common
+online security header tests.
+
 ## Learn More
 - [Astro Documentation](https://docs.astro.build/)
 - [Official Astro Blog Template](https://astro.build/themes/details/astro-blog)

--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,11 @@
+/*
+  X-Frame-Options: DENY
+  X-Content-Type-Options: nosniff
+  X-XSS-Protection: 1; mode=block
+  Referrer-Policy: strict-origin-when-cross-origin
+  Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
+  Content-Security-Policy: default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' https:; font-src 'self'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'
+  Permissions-Policy: camera=(), microphone=(), geolocation=()
+  Cross-Origin-Embedder-Policy: require-corp
+  Cross-Origin-Opener-Policy: same-origin
+  Cross-Origin-Resource-Policy: same-origin

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -6,12 +6,25 @@ export const onRequest: MiddlewareHandler = async ({ request }, next) => {
   response.headers.set('X-Frame-Options', 'DENY');
   response.headers.set('X-Content-Type-Options', 'nosniff');
   response.headers.set('X-XSS-Protection', '1; mode=block');
-  response.headers.set('Referrer-Policy', 'no-referrer-when-downgrade');
+  response.headers.set('Referrer-Policy', 'strict-origin-when-cross-origin');
   response.headers.set('Strict-Transport-Security', 'max-age=63072000; includeSubDomains; preload');
   response.headers.set(
     'Content-Security-Policy',
-    "default-src 'self'; img-src 'self' https:; script-src 'self'; style-src 'self' 'unsafe-inline';"
+    [
+      "default-src 'self'",
+      "script-src 'self'",
+      "style-src 'self' 'unsafe-inline'",
+      "img-src 'self' https:" ,
+      "font-src 'self'",
+      "base-uri 'self'",
+      "form-action 'self'",
+      "frame-ancestors 'none'"
+    ].join('; ')
   );
+  response.headers.set('Permissions-Policy', 'camera=(), microphone=(), geolocation=()');
+  response.headers.set('Cross-Origin-Embedder-Policy', 'require-corp');
+  response.headers.set('Cross-Origin-Opener-Policy', 'same-origin');
+  response.headers.set('Cross-Origin-Resource-Policy', 'same-origin');
 
   return response;
 };


### PR DESCRIPTION
## Summary
- enhance HTTP security headers in middleware
- provide static headers for hosting providers
- document security header setup in README

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6866fe8bb6dc8323b160ef077d7c3645