### PR TITLE
Add blog post on GitHub Copilot prompting

### DIFF
--- a/src/content/blog/prompting-for-impact-in-net.md
+++ b/src/content/blog/prompting-for-impact-in-net.md
@@ -1,0 +1,57 @@
+---
+title: "Prompting for Impact in .NET: Using Copilot to Think, Not Just Code"
+description: "How to go beyond autocomplete and guide GitHub Copilot as a collaborator in your .NET development process."
+pubDate: 2025-07-31T00:00:00.000Z
+author: "Patrick Robinson"
+tags: ["GitHub Copilot", ".NET", "AI", "Prompt Engineering", "Developer Productivity"]
+draft: false
+---
+
+**🎥 Video Recording:**  
+*Coming soon — check back after the event to watch the full talk right here!*
+
+---
+
+## 👋 About the Talk
+
+Most developers use GitHub Copilot to finish lines of code—but what if you could guide it to *think* with you?
+
+In this 45-minute session, originally presented for a .NET User Group Meetup, we explore how to move beyond autocomplete and into intentional collaboration. You’ll learn how to use reusable prompts, custom instructions, and chat modes to steer Copilot more strategically.  
+We also walk through how **“Planning Mode”** lays the groundwork for powerful **“Agent Mode”** results—and how one team used this approach to accomplish in 20 minutes what normally took three days.
+
+Whether you're just getting started or ready to level up your AI-assisted .NET workflow, this talk will give you practical tools and a fresh perspective on how Copilot can become more than just a typing assistant.
+
+---
+
+## 🧠 What You'll Learn
+
+- How to think in prompts, not just commands  
+- The difference between Planning Mode and Agent Mode  
+- How to write reusable prompt patterns  
+- Ways to customize Copilot’s behavior with custom instructions  
+- How chat modes change the interaction dynamic  
+- A live demo refactoring a “big service” using Copilot in .NET
+
+---
+
+## 🖥️ Demo Code
+
+🔗 **GitHub Repo:**  
+*Coming soon — link will be added here once published.*
+
+---
+
+## 🖼️ Slide Deck
+
+📎 **Download Slides (PDF or Google Slides):**  
+*Coming soon — slides will be uploaded after the talk.*
+
+---
+
+## 💬 Questions or Feedback?
+
+Feel free to [reach out](mailto:patrick@onpardev.com) if you attended the talk or watched the recording — I'd love to hear how you're using Copilot in your .NET workflow.
+
+---
+
+*More talks and content coming soon — stay tuned.* 🙌


### PR DESCRIPTION
## Summary
- write new blog post about prompting GitHub Copilot for .NET developers

## Testing
- `n/a`

------
https://chatgpt.com/codex/tasks/task_e_6883e19bcd7c83238ed926877bb899b4