### PR TITLE
add AI cognitive power-up post

### DIFF
--- a/src/content/blog/ai-as-a-cognitive-power-up-not-a-crutch.md
+++ b/src/content/blog/ai-as-a-cognitive-power-up-not-a-crutch.md
@@ -1,0 +1,99 @@
+---
+title: "AI as a Cognitive Power-Up, Not a Crutch"
+description: "How Full Product Developers can use AI to amplify thinking—not outsource it."
+pubDate: 2025-08-05T00:00:00.000Z
+author: Patrick Robinson
+tags: [AI, prompting, developer mindset, full product dev]
+featured: false
+---
+
+> You’re not using AI to think for you.  
+> You’re using it to *think with you*.
+
+As developers, we’ve always used tools to extend our abilities—editors, debuggers, CI/CD pipelines. But AI is something different. It’s not just a tool—it’s a *cognitive partner*. And how we use it matters.
+
+If you’re just letting Copilot fill in code or Claude explain docs, you might feel faster. But are you getting smarter?
+
+### The Research-Backed Advantage
+
+Recent studies show LLMs and agentic systems can:
+- Extend your working memory
+- Scaffold complex problem-solving
+- Support reflective thinking
+
+> “AI can support metacognition and scaffold reasoning.”  
+> — *Shenhav et al., 2017*
+
+Used well, AI can be a power-up for your mind. Used poorly, it becomes a shortcut to stagnation.
+
+---
+
+### What Cognitive Offloading *Should* Look Like
+
+**Bad offloading:**  
+“Write the code for me.”  
+No context. No critique. No growth.
+
+**Good offloading:**  
+“Here’s what I’m trying to build.  
+Here’s what I’ve thought through so far.  
+What am I missing?”
+
+That’s not outsourcing—it’s augmenting.
+
+---
+
+### Three Prompting Habits of High-Cognition Devs
+
+1. **Reflect Before You Prompt**  
+   > What am I trying to do? Where am I stuck?
+
+2. **Co-Think, Don’t Cope**  
+   > Use AI to simulate pair programming or second-brain debugging.
+
+3. **Refactor the Prompt**  
+   > Just like code, your first draft isn’t your best.
+
+---
+
+### From Code to Cognition
+
+Being a Full Product Developer means:
+- Owning your outcomes
+- Asking better questions
+- Staying curious—even when the AI is fast
+
+AI can scaffold your thinking.  
+But it can’t replace your responsibility to think.
+
+---
+
+## Try It: Prompt Templates
+
+**Prompt 1: “What would a senior dev look for here?”**  
+Use to challenge assumptions and grow your mental models.
+
+**Prompt 2: “Explain this in 3 levels: beginner, intermediate, expert.”**  
+Use to reinforce learning across knowledge depths.
+
+**Prompt 3: “What are 3 alternatives I’m not considering?”**  
+Use to avoid tunnel vision and unlock options.
+
+---
+
+## TL;DR
+
+- AI isn’t here to think *for* you—it’s here to think *with* you.
+- Use AI as a scaffold for reasoning, not a crutch for laziness.
+- Better prompts → better cognition → better developers.
+
+---
+
+**Coming Up Next:**  
+Part 2 — *The Art of Prompting as Software Architecture*
+
+---
+
+🧠 Want to grow as a Full Product Developer?  
+Start by growing how you *think with AI.*
+


### PR DESCRIPTION
## Summary
- add new blog post "AI as a Cognitive Power-Up, Not a Crutch" by Patrick Robinson

## Testing
- No tests: documentation-only change

------
https://chatgpt.com/codex/tasks/task_e_6892381cda38832393c50265771d2654